### PR TITLE
Fix fill binding syntax

### DIFF
--- a/src/Avataaars.vue
+++ b/src/Avataaars.vue
@@ -40,7 +40,7 @@
               <g
                 id='Color/Palette/Blue-01'
                 mask='url(#mask-1)'
-                :fill=circleColor>
+                :fill="circleColor">
                 <rect id='🖍Color' x='0' y='0' width='240' height='240'></rect>
               </g>
             </g>


### PR DESCRIPTION
## Summary
- correct the missing quotes around `circleColor` binding

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vue: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847174b8754832081ea1a85352a3d0b