### PR TITLE
Add Jest setup with initial Avataaars test

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  moduleFileExtensions: ['js', 'json', 'vue'],
+  transform: {
+    '^.+\\.vue$': 'vue-jest',
+    '^.+\\.js$': 'babel-jest'
+  },
+  testEnvironment: 'jsdom'
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "./dist/avataaars.common.js",
   "scripts": {
     "dev": "vue serve src/Avataaars.vue",
-    "build": "rm -rf dist && vue build --target lib --name avataaars src/entry.js"
+    "build": "rm -rf dist && vue build --target lib --name avataaars src/entry.js",
+    "test": "jest"
   },
   "homepage": "https://github.com/orgordin/vuejs-avataaars#README.md",
   "keywords": [
@@ -28,6 +29,12 @@
     "*.js"
   ],
   "devDependencies": {
+    "@babel/core": "^7.22.10",
+    "@babel/preset-env": "^7.22.10",
+    "@vue/test-utils": "^1.4.2",
+    "babel-jest": "^29.6.4",
+    "jest": "^29.6.4",
+    "vue-jest": "^3.0.5",
     "vue-template-compiler": "^2.6.10"
   }
 }

--- a/tests/Avataaars.spec.js
+++ b/tests/Avataaars.spec.js
@@ -1,0 +1,9 @@
+import { mount } from '@vue/test-utils';
+import Avataaars from '../src/Avataaars.vue';
+
+describe('Avataaars', () => {
+  it('renders SVG with default props', () => {
+    const wrapper = mount(Avataaars);
+    expect(wrapper.find('svg').exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest and Babel for testing Vue components
- add a basic Avataaars unit test
- add `test` npm script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471893aff4832085484fa685e8384b